### PR TITLE
docs: update usage instructions for snippet sorting in Zed IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ git clone https://github.com/jctosta/python-zed-snippets.git
 
 ## Usage
 
-Start typing the snippet prefix (e.g., `go-func`) in a Go file and press `Tab` to expand the snippet.
+To make snippets appear at the top of the completion list in Zed, add this setting to your Zed settings file:
+
+```json
+{
+    "snippet_sort_order": "top"
+}
+```
+
+Start typing the snippet prefix (e.g., `py-def`) in a Python file and press `Tab` to expand the snippet.
 
 ## Available Snippets
 


### PR DESCRIPTION
This PR ensures snippet completions are prioritized in Zed's completion list, and updates confusing instructions on usage.

**Problem**
- The default Zed config doesn't prioritize snippets in the completions list..

**What this PR changes**
- Add a snippet with the required line to add to Zed's `config.json`.
- Update confusing instructions to test the extension with typing `go-func`.