### PR TITLE
chore: Bump extension version to 0.1.2

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "python-snippets"
 name = "Python Snippets"
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = ["Carlos Tosta <jctosta86@gmail.com>"]
 description = "Python snippets for Zed IDE. A collection of python snippets to improve your development speed."


### PR DESCRIPTION
Quick PR to update extension version to 0.1.2 before publishing.