### PR TITLE
Remove redundant 'py-' prefix and update to new Zed snippet format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ A collection of Python snippets for the [Zed IDE](https://zed.dev) to improve yo
 This extension provides a comprehensive set of snippets for Python development, including:
 
 - Package and import declarations
-- Control structures (if, for, switch)
+- Control structures (if, for, while, try/except)
 - Function and method declarations
-- Common Go patterns
-- HTTP server code
-- Testing helpers
+- Modern Python features (f-strings, type hints, dataclasses)
+- Framework-specific snippets (FastAPI, Pydantic, Typer)
+- Database ORM snippets (SQLAlchemy)
+- Testing helpers (unittest, pytest)
 - And much more!
 
 ## Installation
@@ -42,70 +43,70 @@ To make snippets appear at the top of the completion list in Zed, add this setti
 }
 ```
 
-Start typing the snippet prefix (e.g., `py-def`) in a Python file and press `Tab` to expand the snippet.
+Start typing the snippet prefix (e.g., `def`) in a Python file and press `Tab` to expand the snippet.
 
 ## Available Snippets
 
 | Prefix                  | Description                                      |
 |-------------------------|--------------------------------------------------|
-| `py-im`                 | Import module                                    |
-| `py-ifm`                | Import from module                               |
-| `py-main`               | `if __name__ == "__main__"` entrypoint           |
-| `py-def`                | Function definition                              |
-| `py-class`              | Class definition                                 |
-| `py-prop`               | Property (getter)                                |
-| `py-meth`               | Method definition                                |
-| `py-for`                | For loop                                         |
-| `py-while`              | While loop                                       |
-| `py-if`                 | If statement                                     |
-| `py-ifelse`             | If-else statement                                |
-| `py-elif`               | Elif block                                       |
-| `py-try`                | Try-except block                                 |
-| `py-tryf`               | Try-except-finally block                         |
-| `py-with`               | With context manager                             |
-| `py-ctx`                | Context manager class                            |
-| `py-deco`               | Decorator function                               |
-| `py-lambda`             | Lambda expression                                |
-| `py-lc`                 | List comprehension                               |
-| `py-print`              | Print statement                                  |
-| `py-fs`                 | F-string                                         |
-| `py-logi`               | Logging info message                             |
-| `py-logd`               | Logging debug message                            |
+| `im`                    | Import module                                    |
+| `ifm`                   | Import from module                               |
+| `main`                  | `if __name__ == "__main__"` entrypoint           |
+| `def`                   | Function definition                              |
+| `class`                 | Class definition                                 |
+| `prop`                  | Property (getter)                                |
+| `meth`                  | Method definition                                |
+| `for`                   | For loop                                         |
+| `while`                 | While loop                                       |
+| `if`                    | If statement                                     |
+| `ifelse`                | If-else statement                                |
+| `elif`                  | Elif block                                       |
+| `try`                   | Try-except block                                 |
+| `tryf`                  | Try-except-finally block                         |
+| `with`                  | With context manager                             |
+| `ctx`                   | Context manager class                            |
+| `deco`                  | Decorator function                               |
+| `lambda`                | Lambda expression                                |
+| `lc`                    | List comprehension                               |
+| `print`                 | Print statement                                  |
+| `fs`                    | F-string                                         |
+| `logi`                  | Logging info message                             |
+| `logd`                  | Logging debug message                            |
 | **FastAPI**             |                                                  |
-| `py-fastapi-app`        | FastAPI minimal app                              |
-| `py-fastapi-route`      | FastAPI route handler                            |
-| `py-fastapi-dep`        | FastAPI dependency function                      |
+| `fastapi-app`           | FastAPI minimal app                              |
+| `fastapi-route`         | FastAPI route handler                            |
+| `fastapi-dep`           | FastAPI dependency function                      |
 | **Pydantic**            |                                                  |
-| `py-pydbase`            | Pydantic BaseModel class                         |
-| `py-pydval`             | Pydantic validator                               |
+| `pydbase`               | Pydantic BaseModel class                         |
+| `pydval`                | Pydantic validator                               |
 | **Typer**               |                                                  |
-| `py-typer-app`          | Typer CLI application setup                      |
+| `typer-app`             | Typer CLI application setup                      |
 | **SQLAlchemy**          |                                                  |
-| `py-sa-base`            | SQLAlchemy Base import                           |
-| `py-sa-model`           | SQLAlchemy Model                                 |
-| `py-sa-session`         | SQLAlchemy session setup                         |
+| `sa-base`               | SQLAlchemy Base import                           |
+| `sa-model`              | SQLAlchemy Model                                 |
+| `sa-session`            | SQLAlchemy session setup                         |
 | **unittest**            |                                                  |
-| `py-ut`                 | Unittest TestCase                                |
-| `py-utmain`             | Unittest main entrypoint                         |
+| `ut`                    | Unittest TestCase                                |
+| `utmain`                | Unittest main entrypoint                         |
 | **pytest**              |                                                  |
-| `py-pt`                 | Pytest test function                             |
-| `py-ptp`                | Pytest parametrize test                          |
-| `py-ptfix`              | Pytest fixture                                   |
-| `py-pttable`            | Pytest table-driven test (parametrize)           |
+| `pt`                    | Pytest test function                             |
+| `ptp`                   | Pytest parametrize test                          |
+| `ptfix`                 | Pytest fixture                                   |
+| `pttable`               | Pytest table-driven test (parametrize)           |
 | **Asyncio**             |                                                  |
-| `py-adef`               | Async coroutine definition                       |
-| `py-atg`                | Async TaskGroup context manager definition       |
-| `py-amain`              | Main entrypoint with asyncio.run function        |
+| `adef`                  | Async coroutine definition                       |
+| `atg`                   | Async TaskGroup context manager definition       |
+| `amain`                 | Main entrypoint with asyncio.run function        |
 | **Misc**                |                                                  |
-| `py-dc`                 | Python dataclass                                 |
-| `py-hintf`              | Function with type hints                         |
-| `py-doc`                | Function docstring template                      |
+| `dc`                    | Python dataclass                                 |
+| `hintf`                 | Function with type hints                         |
+| `doc`                   | Function docstring template                      |
 
 ## Examples
 
 ### Function definition
 
-Type `py-def` and press Tab:
+Type `def` and press Tab:
 
 ```python
 def func(args):
@@ -116,7 +117,7 @@ def func(args):
 
 ### If statement
 
-Type `py-if` and press Tab:
+Type `if` and press Tab:
 
 ```python
 if condition:
@@ -127,7 +128,7 @@ if condition:
 
 ### Class with property and method
 
-Type `py-class`, then `py-prop`, and `py-meth` inside the class, and press Tab each time:
+Type `class`, then `prop`, and `meth` inside the class, and press Tab each time:
 
 ```python
 class MyClass(object):
@@ -146,7 +147,7 @@ class MyClass(object):
 
 ### FastAPI minimal app
 
-Type `py-fastapi-app` and press Tab:
+Type `fastapi-app` and press Tab:
 
 ```python
 from fastapi import FastAPI
@@ -162,7 +163,7 @@ def read_root():
 
 ### Pytest test function
 
-Type `py-pt` and press Tab:
+Type `pt` and press Tab:
 
 ```python
 def test_func():
@@ -173,7 +174,7 @@ def test_func():
 
 ### Dataclass
 
-Type `py-dc` and press Tab:
+Type `dc` and press Tab:
 
 ```python
 from dataclasses import dataclass

--- a/extension.toml
+++ b/extension.toml
@@ -1,8 +1,8 @@
 id = "python-snippets"
 name = "Python Snippets"
-version = "0.1.2"
+version = "0.1.3"
 schema_version = 1
 authors = ["Carlos Tosta <jctosta86@gmail.com>"]
 description = "Python snippets for Zed IDE. A collection of python snippets to improve your development speed."
 repository = "https://github.com/jctosta/python-zed-snippets"
-snippets = "./snippets/python.json"
+snippets = ["./snippets/python.json"]

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -1,221 +1,221 @@
 {
     "Import module": {
-        "prefix": "py-im",
+        "prefix": "im",
         "body": "import ${1:module}",
         "description": "Import a module"
     },
     "Import from module": {
-        "prefix": "py-ifm",
+        "prefix": "ifm",
         "body": "from ${1:module} import ${2:item}",
         "description": "Import specific item from a module"
     },
     "Main check": {
-        "prefix": "py-main",
+        "prefix": "main",
         "body": "if __name__ == \"__main__\":\n    $0",
         "description": "Python __main__ entrypoint"
     },
     "Function definition": {
-        "prefix": "py-def",
+        "prefix": "def",
         "body": "def ${1:func}(${2:args}):\n    $0",
         "description": "Function definition"
     },
     "Class definition": {
-        "prefix": "py-class",
+        "prefix": "class",
         "body": "class ${1:ClassName}(${2:object}):\n    def __init__(self, ${3:args}):\n        $0",
         "description": "Class definition"
     },
     "Property (getter)": {
-        "prefix": "py-prop",
+        "prefix": "prop",
         "body": "@property\ndef ${1:attr}(self):\n    $0",
         "description": "Property getter"
     },
     "Method definition": {
-        "prefix": "py-meth",
+        "prefix": "meth",
         "body": "def ${1:method}(self, ${2:args}):\n    $0",
         "description": "Method definition"
     },
     "For loop": {
-        "prefix": "py-for",
+        "prefix": "for",
         "body": "for ${1:item} in ${2:iterable}:\n    $0",
         "description": "For loop"
     },
     "While loop": {
-        "prefix": "py-while",
+        "prefix": "while",
         "body": "while ${1:condition}:\n    $0",
         "description": "While loop"
     },
     "If statement": {
-        "prefix": "py-if",
+        "prefix": "if",
         "body": "if ${1:condition}:\n    $0",
         "description": "If statement"
     },
     "If else statement": {
-        "prefix": "py-ifelse",
+        "prefix": "ifelse",
         "body": "if ${1:condition}:\n    ${2:pass}\nelse:\n    $0",
         "description": "If-else statement"
     },
     "Elif / else": {
-        "prefix": "py-elif",
+        "prefix": "elif",
         "body": "elif ${1:condition}:\n    $0",
         "description": "Elif block"
     },
     "Try except": {
-        "prefix": "py-try",
+        "prefix": "try",
         "body": "try:\n    ${1:pass}\nexcept ${2:Exception} as ${3:e}:\n    $0",
         "description": "Try/except block"
     },
     "Try except finally": {
-        "prefix": "py-tryf",
+        "prefix": "tryf",
         "body": "try:\n    ${1:pass}\nexcept ${2:Exception} as ${3:e}:\n    ${4:pass}\nfinally:\n    $0",
         "description": "Try/except/finally block"
     },
     "With context manager": {
-        "prefix": "py-with",
+        "prefix": "with",
         "body": "with ${1:open('file')} as ${2:f}:\n    $0",
         "description": "With context manager"
     },
     "Context manager class": {
-        "prefix": "py-ctx",
+        "prefix": "ctx",
         "body": "class ${1:ContextManager}:\n    def __enter__(self):\n        $2\n        return self\n    def __exit__(self, exc_type, exc_value, traceback):\n        $0",
         "description": "Context manager class (with __enter__/__exit__)"
     },
     "Decorator": {
-        "prefix": "py-deco",
+        "prefix": "deco",
         "body": "def ${1:decorator}(func):\n    def wrapper(*args, **kwargs):\n        $0\n        return func(*args, **kwargs)\n    return wrapper",
         "description": "Decorator function"
     },
     "Lambda/function expression": {
-        "prefix": "py-lambda",
+        "prefix": "lambda",
         "body": "lambda ${1:x}: ${2:x + 1}",
         "description": "Lambda expression"
     },
     "List comprehension": {
-        "prefix": "py-lc",
+        "prefix": "lc",
         "body": "[${1:x} for ${2:x} in ${3:xs}]",
         "description": "List comprehension"
     },
     "Print statement": {
-        "prefix": "py-print",
+        "prefix": "print",
         "body": "print(${1:\"msg\"})",
         "description": "Print statement"
     },
     "F-string": {
-        "prefix": "py-fs",
+        "prefix": "fs",
         "body": "f\"${1:text} = {${2:var}}\"",
         "description": "F-string"
     },
     "Logging info": {
-        "prefix": "py-logi",
+        "prefix": "logi",
         "body": "import logging\nlogging.info(f\"${1:msg}\")",
         "description": "Logging info message"
     },
     "Logging debug": {
-        "prefix": "py-logd",
+        "prefix": "logd",
         "body": "import logging\nlogging.debug(f\"${1:msg}\")",
         "description": "Logging debug message"
     },
     "FastAPI app": {
-        "prefix": "py-fastapi-app",
+        "prefix": "fastapi-app",
         "body": "from fastapi import FastAPI\n\napp = FastAPI()\n\n@app.get(\"/\")\ndef read_root():\n    return {\"Hello\": \"World\"}",
         "description": "FastAPI minimal application"
     },
     "FastAPI path operation": {
-        "prefix": "py-fastapi-route",
+        "prefix": "fastapi-route",
         "body": "@app.${1:get}(\"/${2:path}\")\ndef ${3:handler}(${4}):\n    $0",
         "description": "FastAPI route handler"
     },
     "FastAPI dependency": {
-        "prefix": "py-fastapi-dep",
+        "prefix": "fastapi-dep",
         "body": "from fastapi import Depends\n\ndef ${1:get_dependency}():\n    $2\n    return $3",
         "description": "FastAPI dependency function"
     },
     "Pydantic BaseModel": {
-        "prefix": "py-pydbase",
+        "prefix": "pydbase",
         "body": "from pydantic import BaseModel\n\nclass ${1:Model}(BaseModel):\n    ${2:field}: ${3:type}\n    ",
         "description": "Pydantic BaseModel class"
     },
     "Pydantic validator": {
-        "prefix": "py-pydval",
+        "prefix": "pydval",
         "body": "from pydantic import validator\n\n@validator(\"${1:field}\")\ndef ${2:validate_field}(cls, v):\n    $0\n    return v",
         "description": "Pydantic validator"
     },
     "Typer CLI app": {
-        "prefix": "py-typer-app",
+        "prefix": "typer-app",
         "body": "import typer\n\napp = typer.Typer()\n\n@app.command()\ndef ${1:hello}(${2:name}: str):\n    print(f\"Hello {name}\")\n\nif __name__ == \"__main__\":\n    app()",
         "description": "Typer CLI app setup"
     },
     "SQLAlchemy Base": {
-        "prefix": "py-sa-base",
+        "prefix": "sa-base",
         "body": "from sqlalchemy.ext.declarative import declarative_base\nBase = declarative_base()",
         "description": "SQLAlchemy Base import"
     },
     "SQLAlchemy Model": {
-        "prefix": "py-sa-model",
+        "prefix": "sa-model",
         "body": "class ${1:Model}(Base):\n    __tablename__ = \"${2:tablename}\"\n    id = Column(Integer, primary_key=True)\n    ${3:field} = Column(${4:Type})",
         "description": "SQLAlchemy ORM model"
     },
     "SQLAlchemy session": {
-        "prefix": "py-sa-session",
+        "prefix": "sa-session",
         "body": "from sqlalchemy.orm import sessionmaker\nSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=${1:engine})\nsession = SessionLocal()",
         "description": "SQLAlchemy session setup"
     },
     "Unittest testcase": {
-        "prefix": "py-ut",
+        "prefix": "ut",
         "body": "import unittest\n\nclass ${1:TestCase}(unittest.TestCase):\n    def setUp(self):\n        $2\n    def test_${3:testname}(self):\n        $0",
         "description": "Unittest TestCase"
     },
     "Unittest main": {
-        "prefix": "py-utmain",
+        "prefix": "utmain",
         "body": "if __name__ == \"__main__\":\n    unittest.main()",
         "description": "Unittest main entrypoint"
     },
     "Pytest function": {
-        "prefix": "py-pt",
+        "prefix": "pt",
         "body": "def test_${1:func}():\n    $0",
         "description": "Pytest function"
     },
     "Pytest parametrize": {
-        "prefix": "py-ptp",
+        "prefix": "ptp",
         "body": "@pytest.mark.parametrize(\"${1:param}\", [${2:values}])\ndef test_${3:func}(${1:param}):\n    $0",
         "description": "Pytest parametrize"
     },
     "Pytest fixture": {
-        "prefix": "py-ptfix",
+        "prefix": "ptfix",
         "body": "@pytest.fixture\ndef ${1:my_fixture}():\n    $0",
         "description": "Pytest fixture"
     },
     "Pytest table driven": {
-        "prefix": "py-pttable",
+        "prefix": "pttable",
         "body": "@pytest.mark.parametrize(\"${1:param}\", [\n    ${2:value1},\n    ${3:value2}\n])\ndef test_${4:func}(${1:param}):\n    $0",
         "description": "Pytest table-driven parametrize"
     },
     "Dataclass": {
-        "prefix": "py-dc",
+        "prefix": "dc",
         "body": "from dataclasses import dataclass\n\n@dataclass\nclass ${1:Name}:\n    ${2:field}: ${3:type}",
         "description": "Python dataclass"
     },
     "Type hint function": {
-        "prefix": "py-hintf",
+        "prefix": "hintf",
         "body": "def ${1:func}(${2:arg}: ${3:type}) -> ${4:rtype}:\n    $0",
         "description": "Function with type hints"
     },
     "Docstring": {
-        "prefix": "py-doc",
+        "prefix": "doc",
         "body": "\"\"\"\n${1:Summary}\n\nArgs:\n    $2\nReturns:\n    $3\n\"\"\"",
         "description": "Function docstring template"
     },
     "Async coroutine": {
-        "prefix": "py-adef",
+        "prefix": "adef",
         "body": "async def ${1:func}(${2:args}):\n    $0",
         "description": "Async coroutine definition"
     },
     "Async task group context manager": {
-        "prefix": "py-atg",
+        "prefix": "atg",
         "body": "async with asyncio.TaskGroup() as ${1:group}:\n    $0",
         "description": "Async TaskGroup context manager"
     },
     "Async main": {
-        "prefix": "py-amain",
+        "prefix": "amain",
         "body": "if __name__ == \"__main__\":\n    asyncio.run($0)",
         "description": "Python __main__ entrypoint for asyncronous"
     }


### PR DESCRIPTION
This PR removes the redundant `py-` prefix from all Python snippets and updates the extension configuration to align with the current Zed documentation.

**Key Changes:**
1.  **Removed `py-` prefix:** According to the [Zed Snippets documentation](https://zed.dev/docs/snippets), snippets defined in a `python.json` file are automatically scoped to the Python language. Therefore, the `py-` prefix is unnecessary identification that adds three extra characters to every trigger, slowing down the development process without providing any benefit.
2.  **Updated `extension.toml`:** Changed the `snippets` field from a string to an array (`snippets = ["./snippets/python.json"]`) to match the [Zed extensions schema](https://zed.dev/docs/extensions/snippets).
3.  **Updated README.md:** 
    *   Updated the documentation and examples to reflect the new, shorter prefixes.
    *   Cleaned up the "Features" section by removing accidental references to Go and switch statements.
4.  **Version Bump:** Incremented the extension version to `0.1.3`.

**Why this change?**
Using shorter prefixes like `def`, `class`, or `im` instead of `py-def`, `py-class`, or `py-im` makes the snippets much more idiomatic and faster to use, especially since Zed already knows these are Python-specific snippets based on the file scope.